### PR TITLE
Style updates for Header area

### DIFF
--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.2"
+      VERSION = "0.21"
     end
   end
 end

--- a/vendor/assets/stylesheets/_alert-banner.scss
+++ b/vendor/assets/stylesheets/_alert-banner.scss
@@ -1,0 +1,36 @@
+// ALERT BANNER
+.hl__alert-banner {
+  background-color: $yellow;
+  color: $black;
+  font-family: $f-trueno;
+
+  @include media-breakpoint-down(sm) {
+    flex-wrap: wrap;
+  }
+
+  &__label {
+    text-transform: uppercase;
+    font-size: 15px;
+    font-weight: $font-weight-bold;
+    letter-spacing: 2.14px;
+    line-height: 1.5em;
+    padding-top: 2px;
+  }
+
+  &__message {
+    font-size: 17px;
+    line-height: 1.5em;
+
+    @include media-breakpoint-down(sm) {
+      padding-top: 8px;
+    }
+
+    a {
+      color: $black;
+      text-decoration: underline;
+      &:hover, &:focus {
+        border-bottom-color: $black;
+      }
+    }
+  }
+}

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -484,6 +484,7 @@ $link-fade:                               border 0.28s cubic-bezier(0.28,1.08,1,
 // custom link styles
 a:not(.btn), .btn-link {
   font-family: $f-trueno;
+  font-size: 1.06rem; // 17px
   font-weight: 600;
   border-bottom: 3px solid transparent;
   transition: $link-fade;
@@ -524,6 +525,13 @@ $grid-breakpoints: (
   xl: 1170px,
   xxl: 1400px // NEW - test if this is alright
 ) !default;
+
+/* Using with media queries
+min-width: @include media-breakpoint-up(sm) { }
+max-width: @include media-breakpoint-down(sm) { }
+single breakpoint: @include media-breakpoint-only(sm) { }
+between breakpoints: @include media-breakpoint-between(md, xl) { }
+*/
 // scss-docs-end grid-breakpoints
 
 
@@ -689,7 +697,7 @@ $headings-font-family:        $font-family-sans-serif !default;
 // $headings-font-style:         null !default;
 $headings-font-weight:        $font-weight-bold !default;
 // $headings-line-height:        1.2 !default;
-$headings-color:              #1e1e1e !default; // default is inherit (#414141)
+$headings-color:              $black !default; // default is inherit (#414141)
 // scss-docs-end headings-variables
 
 // When you need a heading to stand out, consider using a display heading—a larger, slightly more opinionated heading style.
@@ -885,8 +893,8 @@ $btn-link-disabled-color:     $gray-600 !default;
 // $btn-border-radius-sm:        var(--#{$prefix}border-radius-sm) !default;
 // $btn-border-radius-lg:        var(--#{$prefix}border-radius-lg) !default;
 
-// $button-fade:                 all 0.4s ease; // custom variable
-// $btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$button-fade:                 all 0.4s ease; // custom variable
+$btn-transition:              $button-fade !default;
 
 // $btn-hover-bg-shade-amount:       15% !default;
 // $btn-hover-bg-tint-amount:        15% !default;
@@ -1225,7 +1233,7 @@ $nav-link-transition:               $link-fade !default;
 
 // scss-docs-start navbar-variables
 // $navbar-padding-y:                  $spacer * .5 !default;
-// $navbar-padding-x:                  null !default;
+$navbar-padding-x:                  1.0rem !default;
 
 // $navbar-nav-link-padding-x:         .5rem !default;
 
@@ -1236,12 +1244,16 @@ $nav-link-transition:               $link-fade !default;
 // $navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) * .5 !default;
 // $navbar-brand-margin-end:           1rem !default;
 
-// $navbar-toggler-padding-y:          .25rem !default; // custom 0
-// $navbar-toggler-padding-x:          .75rem !default; // custom 0
+$navbar-toggler-padding-y:          .125rem !default;
+$navbar-toggler-padding-x:          .125rem !default;
 // $navbar-toggler-font-size:          $font-size-lg !default;
 // $navbar-toggler-border-radius:      $btn-border-radius !default;
 // $navbar-toggler-focus-width:        $btn-focus-width !default;
 // $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
+
+.navbar-toggler {
+  border-color: transparent !important;
+}
 
 // $navbar-light-color:                rgba(var(--#{$prefix}emphasis-color-rgb), .65) !default;
 // $navbar-light-hover-color:          rgba(var(--#{$prefix}emphasis-color-rgb), .8) !default;
@@ -1255,8 +1267,8 @@ $nav-link-transition:               $link-fade !default;
 // scss-docs-end navbar-variables
 
 // scss-docs-start navbar-dark-variables
-// $navbar-dark-color:                 rgba($white, .55) !default; // custom $white
-// $navbar-dark-hover-color:           rgba($white, .75) !default; // custom $white
+$navbar-dark-color:                 $white !default;
+$navbar-dark-hover-color:           $white !default;
 // $navbar-dark-active-color:          $white !default;
 // $navbar-dark-disabled-color:        rgba($white, .25) !default;
 // $navbar-dark-icon-color:            $navbar-dark-color !default;
@@ -1265,7 +1277,7 @@ $nav-link-transition:               $link-fade !default;
 // $navbar-dark-brand-color:           $navbar-dark-active-color !default;
 // $navbar-dark-brand-hover-color:     $navbar-dark-active-color !default;
 // scss-docs-end navbar-dark-variables
- 
+
  
 // Dropdowns
 //
@@ -1308,7 +1320,7 @@ $dropdown-link-hover-bg:            $background-gray !default;
 // scss-docs-end dropdown-variables
 
 // scss-docs-start dropdown-dark-variables
-// $dropdown-dark-color:               $gray-300 !default;
+$dropdown-dark-color:               $white !default;
 // $dropdown-dark-bg:                  $gray-800 !default;
 // $dropdown-dark-border-color:        $dropdown-border-color !default;
 // $dropdown-dark-divider-bg:          $dropdown-divider-bg !default;
@@ -1322,40 +1334,26 @@ $dropdown-link-hover-bg:            $background-gray !default;
 // $dropdown-dark-header-color:        $gray-500 !default;
 // scss-docs-end dropdown-dark-variables
 
-// custom dropdown styles - may or may not need this section
-// $dropdown-transition: transform 0.5s ease; // custom variable
+// custom nav and dropdown styles
+$dropdown-transition: transform 0.5s ease; // custom variable
 
-// .dropdown-toggle {
-//   &.btn-sm {
-//     & + .dropdown-menu {
-//       .dropdown-item {
-//         padding: 3px 0.47rem;
-//       }
-//     }
-//   }
+a.nav-link, 
+a.dropdown-item {
+  font-weight: normal;
+}
 
-//   &::after {
-//   	transition: $dropdown-transition;
-//     border-top: 0.5em solid currentColor !important;
-//     border-left: 0.425em solid transparent !important;
-//     border-right: 0.425em solid transparent !important;
-//     vertical-align: 1px !important;
-//   }
+.dropdown-toggle {
+  &::after {
+  	transition: $dropdown-transition;
+  }
 
-//   &[aria-expanded="true"]{
-//     border-radius: 4px 4px 0 0;
-
-//     &::after {
-//       transform: scaleY(-1);
-//     }
-//   }
-// }
-
-// .show.dropdown-menu {
-//   border-top: none;
-//   border-radius: 0 0 4px 4px;
-// }
-// end custom dropdown styles
+  &[aria-expanded="true"]{
+    &::after {
+      transform: scaleY(-1);
+    }
+  }
+}
+// end custom nav and dropdown styles
 
 
 // Pagination

--- a/vendor/assets/stylesheets/_header-child.scss
+++ b/vendor/assets/stylesheets/_header-child.scss
@@ -1,12 +1,7 @@
-// slight customization from PatternLab (with the site title link) + navbar at bottom
+// harvard header component
+// slight customization from PatternLab (with the site title link)
 
-// child theme header
 .hl__header-child {
-
-  @media($bp-small-min) {
-    display: flex;
-  }
-
   &__title {
     background-image: linear-gradient(-46deg, $c-theme-secondary 0%, $c-theme-secondary-dark 100%);
     color: $c-font-inverse;
@@ -22,9 +17,9 @@
       font-size: 20px;
       font-style: italic;
       font-weight: 400;
-      line-height: 1;
+      line-height: 1.1;
 
-      @media($bp-small-min) {
+      @include media-breakpoint-up(sm) {
         font-size: 24px;
         line-height: 1.3;
       }
@@ -38,12 +33,12 @@
       font-family: $f-trueno;
       font-size: 26px;
       font-style: normal;
-      font-weight: 700;
+      font-weight: $font-weight-bold;
       letter-spacing: 1.52px;
       line-height: 1;
       text-transform: uppercase;
 
-      @media($bp-small-min) {
+      @include media-breakpoint-up(sm) {
         font-size: 32px;
         line-height: 1.25;
       }
@@ -68,54 +63,20 @@
 
   &__logo {
     background-color: $c-theme-base;
-    display: flex;
-      align-items: center;
-    flex: none;
     min-height: 44px;
 
     a {
       padding: 10px 20px;
-    }
-  }
-}
+      margin: 4px;
+      border: none;
 
-
-// navbar
-.topbar.navbar {
-  background: $c-theme-ink !important;
-
-  a {
-    color: $white;
-
-    &:focus, &:hover {
-      border-color: rgba($white, 0.3);
-    }
-  }
-
-  .badge {
-    background-color: $c-theme-blue;
-  }
-
-  // full width styles
-  &.navbar-expand-md {
-    .container {
-      max-width: 100%;
-      padding: 0;
-    }
-    .navbar-nav {
-      .nav-link {
-        padding: 0;
-        margin: 0.5rem 1rem;
+      @include media-breakpoint-down(md) {
+        padding: 6px 10px;
       }
     }
-  }
 
-  // hamburger styles
-  .navbar-toggler[aria-expanded="true"] + .navbar-collapse {
-    .navbar-nav .nav-link {
-      margin: 0.5rem 1rem 0 0;
-      padding: 0;
-      display: inline-block;
+    .hl__logo-shield {
+      max-height: 40px;
     }
   }
 }

--- a/vendor/assets/stylesheets/_topbar-nav.scss
+++ b/vendor/assets/stylesheets/_topbar-nav.scss
@@ -1,0 +1,47 @@
+// top navbar
+
+nav.navbar.topbar {
+  min-height: 60px;
+  
+  @include media-breakpoint-up(md) {
+    max-height: 60px;
+  }
+
+  // adjust padding to make full width
+  > .container {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  // remove linked logo on right side
+  // doing with css rather than modifying the .html.erb file
+  a.navbar-logo {
+    display: none;
+  }
+
+  // dropdown menu bar
+  a.nav-link {
+    padding: 0;
+    margin: 0.5rem;
+  }
+
+  .dropdown-menu[data-bs-popper] {
+    left: -73px;
+  }
+  
+  // dropdown menu bar for dark theme
+  &.navbar-dark {
+    a.nav-link {
+      &:hover, &:focus {
+        border-color: rgba($white, 0.3);
+      }
+    }
+  }
+
+  // hampburger menu
+  @include media-breakpoint-down(md) {
+    .dropdown-toggle.nav-link {
+      display: inline-block;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -1,33 +1,37 @@
 // This is the main scss file for Harvard Patterns
 
+@import 'bootstrap/mixins';
+
 @import 'fonts';
 
 // CUSTOM BOOTSTRAP 5 VARIABLE OVERRIDES
 @import 'harvard-bootstrap';
 
 // GLOBAL STYLES & MIXINS
-@import 'variables';
-@import 'breakpoints';
+// @import 'variables';
+// @import 'breakpoints';
 @import 'colors';
-@import 'container';
-@import 'typography';
-@import 'global';
-@import 'links-and-buttons';
-@import 'visually-hidden';
+// @import 'container';
+// @import 'typography';
+// @import 'global';
+// @import 'links-and-buttons';
+// @import 'visually-hidden';
 
 // PATTERNS
-@import 'facets';
-@import 'footer';
+@import 'alert-banner';
+// @import 'facets';
+// @import 'footer';
 @import 'header-child';
-@import 'homepage';
-@import 'icon-list';
-@import 'index-map-explorer';
-@import 'item-detail';
-@import 'leaflet-hgl';
-@import 'modal-windows';
-@import 'other-screens';
-@import 'search-results';
-@import 'searchbar';
+// @import 'homepage';
+// @import 'icon-list';
+// @import 'index-map-explorer';
+// @import 'item-detail';
+// @import 'leaflet-hgl';
+// @import 'modal-windows';
+// @import 'other-screens';
+// @import 'search-results';
+// @import 'searchbar';
+@import 'topbar-nav';
 
 // BOOTSTRAP 5
 @import 'bootstrap';


### PR DESCRIPTION
**Style updates for Header area**
* * *

**JIRA Ticket**: [LTSARC-26](https://at-harvard.atlassian.net/browse/LTSARC-26)

# What does this Pull Request do?
Implement style updates to the header area and removes references to custom files not currently using.

# How should this be tested?
Using the [arclight repo branch LTSARC-26](https://github.com/harvard-lts/arclight/tree/LTSARC-26), link the gem to ArcLight's `Gemfile` from this branch:

gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-26"

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.21).

Start up ArcLight and confirm the following header styles:

- [ ] [Alert banner](https://harvard-library-web-team.gitlab.io/Harvard-Patterns/?p=organisms-site-alert-banner) matches the pattern lab design, excluding the dismiss button
- [ ] [Child theme header ](https://harvard-library-web-team.gitlab.io/Harvard-Patterns/?p=organisms-header-child-as-teal)is implemented with a teal background.
- [ ] ArcLight logo is removed from the header (black bar).
- [ ] New favicon is present in the tab (will now appear as Harvard shield)
- [ ] “Request” dropdown is styled with dark background
- [ ] All header updates are mobile responsive

Once these styles are confirmed and approved, I will create a tag and then have another PR for officially incorporating this gem into ArcLight.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No


[LTSARC-26]: https://at-harvard.atlassian.net/browse/LTSARC-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ