### PR TITLE
Style updates for Masthead and Navigation

### DIFF
--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.22"
+      VERSION = "0.23"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.21"
+      VERSION = "0.22"
     end
   end
 end

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -484,7 +484,6 @@ $link-fade:                               border 0.28s cubic-bezier(0.28,1.08,1,
 // custom link styles
 a:not(.btn), .btn-link {
   font-family: $f-trueno;
-  font-size: 1.06rem; // 17px
   font-weight: 600;
   border-bottom: 3px solid transparent;
   transition: $link-fade;
@@ -1337,11 +1336,6 @@ $dropdown-dark-color:               $white !default;
 // custom nav and dropdown styles
 $dropdown-transition: transform 0.5s ease; // custom variable
 
-a.nav-link, 
-a.dropdown-item {
-  font-weight: $font-weight-base;
-}
-
 .dropdown-toggle {
   &::after {
   	transition: $dropdown-transition;
@@ -1726,7 +1720,7 @@ $card-border-color:                 $gray-400 !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-$breadcrumb-font-size:              1.06rem !default; // 17px
+// $breadcrumb-font-size:              null !default;
 // $breadcrumb-padding-y:              0 !default;
 // $breadcrumb-padding-x:              0 !default;
 // $breadcrumb-item-padding-x:         .5rem !default;

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -1339,7 +1339,7 @@ $dropdown-transition: transform 0.5s ease; // custom variable
 
 a.nav-link, 
 a.dropdown-item {
-  font-weight: normal;
+  font-weight: $font-weight-base;
 }
 
 .dropdown-toggle {
@@ -1415,7 +1415,7 @@ ul.pagination, ul.pagination a {
   border-bottom: none;
 }
 .pagination > .disabled > a {
-	font-weight: normal;
+	font-weight: $font-weight-base;
 }
 // end custom pagination styles
 
@@ -1726,7 +1726,7 @@ $card-border-color:                 $gray-400 !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-// $breadcrumb-font-size:              null !default;
+$breadcrumb-font-size:              1.06rem !default; // 17px
 // $breadcrumb-padding-y:              0 !default;
 // $breadcrumb-padding-x:              0 !default;
 // $breadcrumb-item-padding-x:         .5rem !default;

--- a/vendor/assets/stylesheets/arclight/_al-masthead.scss
+++ b/vendor/assets/stylesheets/arclight/_al-masthead.scss
@@ -1,0 +1,33 @@
+// ARCLIGHT
+// masthead navigation
+.al-masthead {
+  nav {
+    li.nav-item {
+      a {
+        padding: 0;
+      }
+    }
+  }
+
+  &.bg-light {
+    li.nav-item.active {
+      &.active a {
+        border-bottom-color: $gray-700 // var(--al-mastead-active-link-color);
+      }
+    }
+  }
+
+  &.bg-dark {
+    li.nav-item.active {
+      &.active a {
+        border-bottom-color: $white;
+      }
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    .nav-links {
+      margin-bottom: 1.5rem;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -33,5 +33,8 @@
 // @import 'searchbar';
 @import 'topbar-nav';
 
+// ARCLIGHT PATTERNS
+@import 'arclight/al-masthead';
+
 // BOOTSTRAP 5
 @import 'bootstrap';


### PR DESCRIPTION
**Style updates for Masthead and Navigation**
* * *

**JIRA Ticket**: [LTSARC-27](https://at-harvard.atlassian.net/browse/LTSARC-27)

# What does this Pull Request do?
Implement style updates to the masthead, main navigation, and breadcrumbs areas.

# How should this be tested?
Using the [arclight repo branch LTSARC-27](https://github.com/harvard-lts/arclight/tree/LTSARC-27), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-27"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.23).

Start up ArcLight and confirm the following style updates:

- [ ] The masthead displays the updated heading: “Archival Collections at Harvard”.
- [ ] Active page in the main navigation is underlined for clarity (it toggles between Repositories and Collections).
- [ ] Breadcrumb text is in Trueno font and font-size is consistent (regardless of whether or not it's a link)

Once these styles are confirmed and approved, I will create a tag and then have another PR for officially incorporating this gem into ArcLight.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No


[LTSARC-27]: https://at-harvard.atlassian.net/browse/LTSARC-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ