### PR TITLE
Style updates for Search Box

### DIFF
--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.22"
+      VERSION = "0.23"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.21"
+      VERSION = "0.22"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.23"
+      VERSION = "0.24"
     end
   end
 end

--- a/vendor/assets/stylesheets/_global.scss
+++ b/vendor/assets/stylesheets/_global.scss
@@ -19,39 +19,44 @@ html {
   }
 }
 
-body {
-  color: $c-font-base;
-  font-family: $f-lora;
-  font-size: 17px;
-  line-height: (29 / 17);  // line-height / font-size
-  position: relative;
+// body {
+//   color: $c-font-base;
+//   font-family: $f-lora;
+//   font-size: 17px;
+//   line-height: (29 / 17);  // line-height / font-size
+//   position: relative;
 
-  // ADD BACK IN WHEN MAKE DECISION ABOUT BREAKPOINTS
-  // @media ($bp-small-min) {
-  //   font-size: 19px;
-  //   line-height: (32 / 19); // line-height / font-size
-  // }
+//   // ADD BACK IN WHEN MAKE DECISION ABOUT BREAKPOINTS
+//   // @media ($bp-small-min) {
+//   //   font-size: 19px;
+//   //   line-height: (32 / 19); // line-height / font-size
+//   // }
 
-  & * {
-    margin-top: 0;
-  }
-}
+//   & * {
+//     margin-top: 0;
+//   }
+// }
 
-b,
-strong {
-  font-weight: 700;
-}
+// b,
+// strong {
+//   font-weight: 700;
+// }
 
-img {
-  height: auto;
-  max-width: 100%;
-}
+// img {
+//   height: auto;
+//   max-width: 100%;
+// }
 
 button {
   cursor: pointer;
 }
 
-input,
-textarea {
-  font-family: $f-lora;
+// input,
+// textarea {
+//   font-family: $f-lora;
+// }
+
+// add space to top of main container (arclight)
+#main-container {
+  padding-top: 2rem;
 }

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -310,7 +310,7 @@ $primary:       $blue !default;
 $info:          $teal !default; 
 // $warning:       $yellow !default;
 // $danger:        $red !default;
-// $light:         $gray-100 !default;
+$light:         $background-gray!default;
 // $dark:          $gray-900 !default;
 // scss-docs-end theme-color-variables
 
@@ -654,8 +654,8 @@ $font-family-base:            $f-lora !default;
 // $font-size-base affects the font size of the body text
 $font-size-root:              null !default; // NEW (browser default of 16px can be overridden by modifying the $font-size-root variable)
 $font-size-base:              1.188rem !default; // 19px // Assumes the browser default, typically `16px`
-$font-size-sm:                0.938rem !default; // 25px
-$font-size-lg:                1.563rem !default; // 15px
+$font-size-sm:                0.938rem !default; // 15px
+$font-size-lg:                1.563rem !default; // 25px
 
 // $font-weight-lighter:         lighter !default;
 // $font-weight-light:           300 !default;
@@ -689,6 +689,15 @@ $h6-font-size:                1rem !default; // 15px or 16px?
 //   6: $h6-font-size
 // ) !default;
 // scss-docs-end font-sizes
+
+// custom font styles - mobile responsive sizes)
+@include media-breakpoint-down(sm) {
+  body, a:not(.btn) {
+    font-size: 17px !important;
+    line-height: (29 / 17) !important;  // line-height / font-size
+  }
+}
+// end custom font styles
 
 // scss-docs-start headings-variables
 $headings-margin-bottom:      1.25rem !default; // 20px
@@ -905,6 +914,20 @@ $btn-transition:              $button-fade !default;
 // $btn-active-border-tint-amount:   10% !default;
 // scss-docs-end btn-variables
 
+// custom button styles
+.btn {
+  letter-spacing: 1.17px;
+  text-transform: uppercase;
+
+  &.btn-primary {
+    &:hover, &:focus {
+      background: $indigo;
+      border-color: $indigo;
+    }
+  }
+}
+// end custom button styles
+
 
 // Forms
 
@@ -926,10 +949,10 @@ $btn-transition:              $button-fade !default;
 
 // scss-docs-start form-input-variables
 // $input-padding-y:                       $input-btn-padding-y !default;
-// $input-padding-x:                       $input-btn-padding-x !default;
+$input-padding-x:                       $input-btn-padding-x !default;
 // $input-font-family:                     $input-btn-font-family !default;
 // $input-font-size:                       $input-btn-font-size !default;
-// $input-font-weight:                     $font-weight-base !default;
+$input-font-weight:                     300 !default;
 // $input-line-height:                     $input-btn-line-height !default;
 
 // $input-padding-y-sm:                    $input-btn-padding-y-sm !default;
@@ -1039,12 +1062,18 @@ $btn-transition:              $button-fade !default;
 // $input-group-addon-border-color:        $input-border-color !default;
 // scss-docs-end input-group-variables
 
+// custom input-group styles
+.input-group-text {
+  font-family: $font-family-sans-serif;
+}
+// end custom input-group styles
+
 // scss-docs-start form-select-variables
 // $form-select-padding-y:             $input-padding-y !default;
-// $form-select-padding-x:             $input-padding-x !default;
+$form-select-padding-x:             $input-padding-x !default;
 // $form-select-font-family:           $input-font-family !default;
 // $form-select-font-size:             $input-font-size !default;
-// $form-select-indicator-padding:     $form-select-padding-x * 3 !default; // Extra padding for background-image
+$form-select-indicator-padding:     $form-select-padding-x * 2 !default; // Extra padding for background-image
 // $form-select-font-weight:           $input-font-weight !default;
 // $form-select-line-height:           $input-line-height !default;
 // $form-select-color:                 $input-color !default;
@@ -1720,7 +1749,7 @@ $card-border-color:                 $gray-400 !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-// $breadcrumb-font-size:              null !default;
+$breadcrumb-font-size:              1.06rem !default;
 // $breadcrumb-padding-y:              0 !default;
 // $breadcrumb-padding-x:              0 !default;
 // $breadcrumb-item-padding-x:         .5rem !default;

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -484,7 +484,6 @@ $link-fade:                               border 0.28s cubic-bezier(0.28,1.08,1,
 // custom link styles
 a:not(.btn), .btn-link {
   font-family: $f-trueno;
-  font-size: 1.06rem; // 17px
   font-weight: 600;
   border-bottom: 3px solid transparent;
   transition: $link-fade;
@@ -1337,11 +1336,6 @@ $dropdown-dark-color:               $white !default;
 // custom nav and dropdown styles
 $dropdown-transition: transform 0.5s ease; // custom variable
 
-a.nav-link, 
-a.dropdown-item {
-  font-weight: $font-weight-base;
-}
-
 .dropdown-toggle {
   &::after {
   	transition: $dropdown-transition;
@@ -1726,7 +1720,7 @@ $card-border-color:                 $gray-400 !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-$breadcrumb-font-size:              1.06rem !default; // 17px
+// $breadcrumb-font-size:              null !default;
 // $breadcrumb-padding-y:              0 !default;
 // $breadcrumb-padding-x:              0 !default;
 // $breadcrumb-item-padding-x:         .5rem !default;

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -1339,7 +1339,7 @@ $dropdown-transition: transform 0.5s ease; // custom variable
 
 a.nav-link, 
 a.dropdown-item {
-  font-weight: normal;
+  font-weight: $font-weight-base;
 }
 
 .dropdown-toggle {
@@ -1415,7 +1415,7 @@ ul.pagination, ul.pagination a {
   border-bottom: none;
 }
 .pagination > .disabled > a {
-	font-weight: normal;
+	font-weight: $font-weight-base;
 }
 // end custom pagination styles
 
@@ -1726,7 +1726,7 @@ $card-border-color:                 $gray-400 !default;
 // Breadcrumbs
 
 // scss-docs-start breadcrumb-variables
-// $breadcrumb-font-size:              null !default;
+$breadcrumb-font-size:              1.06rem !default; // 17px
 // $breadcrumb-padding-y:              0 !default;
 // $breadcrumb-padding-x:              0 !default;
 // $breadcrumb-item-padding-x:         .5rem !default;

--- a/vendor/assets/stylesheets/_visually-hidden.scss
+++ b/vendor/assets/stylesheets/_visually-hidden.scss
@@ -1,12 +1,12 @@
 .sr-only {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
   position: absolute;
   width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
 }
 
 @mixin sr-only {
@@ -20,17 +20,9 @@
   border: 0;
 }
 
-// elements are are visually hidden
-.searchbar__wrapper:not(.homepage__search) .submit-search-text /* 'search' text inside searchbar */,
-.homepage h2 /* 'find by category/location' headings on homepage */ {
+// elements that are visually hidden
+// .searchbar__wrapper:not(.homepage__search) .submit-search-text /* 'search' text inside searchbar */,
+// .homepage h2 /* 'find by category/location' headings on homepage */,
+#search .submit-search-text  /* 'search' text inside searchbar */ {
   @include sr-only();
-}
-
-
-
-
-
-// hidden everywhere
-.hidden {
-    display: none;
 }

--- a/vendor/assets/stylesheets/arclight/_al-masthead.scss
+++ b/vendor/assets/stylesheets/arclight/_al-masthead.scss
@@ -1,0 +1,33 @@
+// ARCLIGHT
+// masthead navigation
+.al-masthead {
+  nav {
+    li.nav-item {
+      a {
+        padding: 0;
+      }
+    }
+  }
+
+  &.bg-light {
+    li.nav-item.active {
+      &.active a {
+        border-bottom-color: $gray-700 // var(--al-mastead-active-link-color);
+      }
+    }
+  }
+
+  &.bg-dark {
+    li.nav-item.active {
+      &.active a {
+        border-bottom-color: $white;
+      }
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    .nav-links {
+      margin-bottom: 1.5rem;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/arclight/_al-searchbar.scss
+++ b/vendor/assets/stylesheets/arclight/_al-searchbar.scss
@@ -1,0 +1,74 @@
+// search area
+// TO DO: determine if these styles are universal to other *lites or should be specific to arclight by adding `.hl__arclight`
+.navbar-search {
+  border-top: 0;
+  border-bottom: 1px solid $border-gray;
+  padding-bottom: 2rem;
+
+  form.search-query-form {
+    flex-wrap: wrap;
+
+    @include media-breakpoint-up(lg) {
+      width: 100%;
+    }
+
+    // dropdown options
+    @include media-breakpoint-up(md) {
+      #within_collection {
+        width: 15rem;
+      }
+      
+      #search_field {
+        width: 10rem;
+      }
+    }
+
+    // make mobile responsive
+    @include media-breakpoint-down(sm) {
+      .within-collection-dropdown {
+        flex: auto;
+      }
+
+      #search_field {
+        width: 100%;
+        border-radius: $border-radius $border-radius 0 0;
+        border-bottom: none;
+      }
+
+      .search-autocomplete-wrapper,
+      #q {
+        border-bottom-left-radius: $border-radius !important;
+      }
+
+      #search {
+        border-radius: 0 0 $border-radius 0;
+      }
+    }
+
+    // placeholder text
+    #q::placeholder {
+      font-style: italic;
+    }
+
+    // search button
+    #search {
+      align-items: center;
+    }
+
+    // advanced search button
+    .btn.advanced_search {
+      align-content: center;
+    }
+  }
+}
+
+// advanced search form facets
+#advanced_search_facets {
+  .facet-content .card-body {
+    padding: 0.75rem 1.438rem;
+  }
+
+  .facet-limit {
+    margin-bottom: 1rem;
+  }
+}

--- a/vendor/assets/stylesheets/arclight/_al-searchbar.scss
+++ b/vendor/assets/stylesheets/arclight/_al-searchbar.scss
@@ -1,6 +1,6 @@
 // search area
 // TO DO: determine if these styles are universal to other *lites or should be specific to arclight by adding `.hl__arclight`
-.navbar-search {
+.navbar.navbar-search {
   border-top: 0;
   border-bottom: 1px solid $border-gray;
   padding-bottom: 2rem;

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -33,5 +33,8 @@
 // @import 'searchbar';
 @import 'topbar-nav';
 
+// ARCLIGHT PATTERNS
+@import 'arclight/al-masthead';
+
 // BOOTSTRAP 5
 @import 'bootstrap';

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -13,9 +13,9 @@
 @import 'colors';
 // @import 'container';
 // @import 'typography';
-// @import 'global';
+@import 'global';
 // @import 'links-and-buttons';
-// @import 'visually-hidden';
+@import 'visually-hidden';
 
 // PATTERNS
 @import 'alert-banner';
@@ -35,6 +35,7 @@
 
 // ARCLIGHT PATTERNS
 @import 'arclight/al-masthead';
+@import 'arclight/_al-searchbar';
 
 // BOOTSTRAP 5
 @import 'bootstrap';


### PR DESCRIPTION
**Style updates for Search Box**
* * *

**JIRA Ticket**: [LTSARC-28](https://at-harvard.atlassian.net/browse/LTSARC-28)

# What does this Pull Request do?
Implement style updates to the search box area.

# How should this be tested?
Using the [arclight repo branch LTSARC-28](https://github.com/harvard-lts/arclight/tree/LTSARC-28), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-28"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.24).

Start up ArcLight and confirm the following style updates:

- [x] Search box button text has consistent and appropriate spacing ("Advanced Search", and blue search button should only have icon now).
- [x] Search box is placed within a light grey bar with a small light gray bottom border.
- [x] “Advanced Search” is displayed cleanly (removed extra spacing under facet dropdowns, “Start Over” styled as an outlined button).
- [x] Search box flows smoothly across screen sizes

Once these styles are confirmed and approved, I will create a tag and then have another PR for officially incorporating this gem into ArcLight.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

[LTSARC-28]: https://at-harvard.atlassian.net/browse/LTSARC-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ