### PR TITLE
Style updates for Results page

### DIFF
--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.4"
+      VERSION = "0.5"
     end
   end
 end

--- a/vendor/assets/stylesheets/_facets.scss
+++ b/vendor/assets/stylesheets/_facets.scss
@@ -1,358 +1,358 @@
-.facets__rail {
-  position: absolute;
-  left: 0;
-  transform: translateX(-100%);
-  width: 100%;
-  z-index: 3;
-  transition: all 0.7s ease;
-  background: $background-gray;
+// .facets__rail {
+//   position: absolute;
+//   left: 0;
+//   transform: translateX(-100%);
+//   width: 100%;
+//   z-index: 3;
+//   transition: all 0.7s ease;
+//   background: $background-gray;
 
-  @media($bp-medium-max){
-    margin-top: -35px;
-  }
+//   @media($bp-medium-max){
+//     margin-top: -35px;
+//   }
 
-  &.open {
-    transform: none;
-  }
+//   &.open {
+//     transform: none;
+//   }
 
-  // expand/collapse all toggle
-  .toggle-wrapper {
-    overflow: hidden;
+//   // expand/collapse all toggle
+//   .toggle-wrapper {
+//     overflow: hidden;
 
-    .toggle-all-facets {
-      font-family: $f-trueno;
-      font-size: 13px;
-      font-weight: 300;
-      border: none;
-      background: $background-gray;
-      padding: 6px 25px;
-      float: right;
+//     .toggle-all-facets {
+//       font-family: $f-trueno;
+//       font-size: 13px;
+//       font-weight: 300;
+//       border: none;
+//       background: $background-gray;
+//       padding: 6px 25px;
+//       float: right;
 
-      &:hover, &:focus {
-        background: $border-gray;
-        color: $c-white;
-      }
+//       &:hover, &:focus {
+//         background: $border-gray;
+//         color: $c-white;
+//       }
 
-      .expand-text {
-        display: inline-block;
-      }
+//       .expand-text {
+//         display: inline-block;
+//       }
 
-      .collapse-text {
-        display: none;
-      }
+//       .collapse-text {
+//         display: none;
+//       }
 
-      &[aria-expanded=true] {
-        .expand-text {
-          display: none;
-        }
+//       &[aria-expanded=true] {
+//         .expand-text {
+//           display: none;
+//         }
 
-        .collapse-text {
-          display: inline-block;
-        }
-      }
-    }
-  }
+//         .collapse-text {
+//           display: inline-block;
+//         }
+//       }
+//     }
+//   }
 
-  // '«' button to show/hide facets rail
-  .btn-show-facets {
-    height: 300px;
-    width: 40px;
-    position: absolute;
-    right: -40px;
-    top: 0%;
-    background: $background-gray;
-    border: none;
+//   // '«' button to show/hide facets rail
+//   .btn-show-facets {
+//     height: 300px;
+//     width: 40px;
+//     position: absolute;
+//     right: -40px;
+//     top: 0%;
+//     background: $background-gray;
+//     border: none;
 
-    .btn-show-facets__label {
-      transform: rotate(270deg) translate(0,-130px);
-      font-family: $f-trueno;
-      text-transform: uppercase;
-      font-size: 18px;
-      font-weight: bold;
-      display: block;
-      width: 300px;
-      height: 40px;
-      text-align: right;
-      padding-right: 40px;
-    }
-  }
+//     .btn-show-facets__label {
+//       transform: rotate(270deg) translate(0,-130px);
+//       font-family: $f-trueno;
+//       text-transform: uppercase;
+//       font-size: 18px;
+//       font-weight: bold;
+//       display: block;
+//       width: 300px;
+//       height: 40px;
+//       text-align: right;
+//       padding-right: 40px;
+//     }
+//   }
 
-  .btn-hide-facets {
-    background: transparent;
-    border: none;
-    position: absolute;
-    right: 10px;
-    top: 6px;
-  }
+//   .btn-hide-facets {
+//     background: transparent;
+//     border: none;
+//     position: absolute;
+//     right: 10px;
+//     top: 6px;
+//   }
 
-  // from 'https://css.gg/chevron-double-right'
-  .angle-double-right, .angle-double-left {
-    box-sizing: border-box;
-    // position: relative;
-    // display: inline-block;
-    transform: scale(var(--ggs,1));
-    width: 22px;
-    height: 22px;
-    // left: 6px;
-    transition: transform 0.5s ease;
+//   // from 'https://css.gg/chevron-double-right'
+//   .angle-double-right, .angle-double-left {
+//     box-sizing: border-box;
+//     // position: relative;
+//     // display: inline-block;
+//     transform: scale(var(--ggs,1));
+//     width: 22px;
+//     height: 22px;
+//     // left: 6px;
+//     transition: transform 0.5s ease;
 
-    &::before, &::after {
-      content: "";
-      display: inline-block;
-      box-sizing: border-box;
-      position: absolute;
-      width: 8px;
-      height: 8px;
-      border-right: 2px solid;
-      border-top: 2px solid;
-      transform: rotate(45deg);
-      top: 16px;
-      right: 15px;
-    }
+//     &::before, &::after {
+//       content: "";
+//       display: inline-block;
+//       box-sizing: border-box;
+//       position: absolute;
+//       width: 8px;
+//       height: 8px;
+//       border-right: 2px solid;
+//       border-top: 2px solid;
+//       transform: rotate(45deg);
+//       top: 16px;
+//       right: 15px;
+//     }
 
-    &::after {
-      right: 20px;
-    }
-  }
+//     &::after {
+//       right: 20px;
+//     }
+//   }
 
-  .angle-double-left {
-    &::before, &::after {
-      transform: scaleX(-1) rotate(45deg);
-    }
-  }
+//   .angle-double-left {
+//     &::before, &::after {
+//       transform: scaleX(-1) rotate(45deg);
+//     }
+//   }
 
-  @media($bp-medium-min) {
-    position: static;
-    background: transparent;
-    transform: none;
+//   @media($bp-medium-min) {
+//     position: static;
+//     background: transparent;
+//     transform: none;
 
-    .btn-show-facets, .btn-hide-facets {
-      display: none;
-    }
-  }
+//     .btn-show-facets, .btn-hide-facets {
+//       display: none;
+//     }
+//   }
 
-  // 'Limit your search' heading
-  .facets__heading {
-    font-size: 20px;
-    line-height: 30px;
-    letter-spacing: 1.5px;
-    padding: 10px 0 20px 25px;
-    margin: 0;
+//   // 'Limit your search' heading
+//   .facets__heading {
+//     font-size: 20px;
+//     line-height: 30px;
+//     letter-spacing: 1.5px;
+//     padding: 10px 0 20px 25px;
+//     margin: 0;
 
-    @media($bp-medium-min){
-      padding: 0 0 20px 0;
-    }
-  }
+//     @media($bp-medium-min){
+//       padding: 0 0 20px 0;
+//     }
+//   }
 
-  // facet container
-  .facets__container {
-    background-color: $background-gray;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
+//   // facet container
+//   .facets__container {
+//     background-color: $background-gray;
+//     padding-bottom: 10px;
+//     margin-bottom: 20px;
 
-    // spacing + border for facet categories
-    .accordion {
-      margin-bottom: 0;
+//     // spacing + border for facet categories
+//     .accordion {
+//       margin-bottom: 0;
 
-      .accordion-navigation {
-        border-bottom: 1px solid $border-gray;
-        // padding: 25px 0;
-        margin: 0 25px;
-      }
+//       .accordion-navigation {
+//         border-bottom: 1px solid $border-gray;
+//         // padding: 25px 0;
+//         margin: 0 25px;
+//       }
 
-      &:last-child {
-        .accordion-navigation {
-          border-bottom: 0;
-        }
-      }
-    }
+//       &:last-child {
+//         .accordion-navigation {
+//           border-bottom: 0;
+//         }
+//       }
+//     }
 
-    // facet categories
-    a.facet__title {
-      border: none;
-      color: $c-font-heading;
-      font-size: 14px;
-      letter-spacing: 2px;
-      text-transform: uppercase;
-      padding: 25px 0;
-      display: block;
-    }
+//     // facet categories
+//     a.facet__title {
+//       border: none;
+//       color: $c-font-heading;
+//       font-size: 14px;
+//       letter-spacing: 2px;
+//       text-transform: uppercase;
+//       padding: 25px 0;
+//       display: block;
+//     }
 
-    // facet values (selectable options)
-    .facet-values {
-      font-family: $f-trueno;
-      padding: 0;
-      margin-bottom: 25px;
+//     // facet values (selectable options)
+//     .facet-values {
+//       font-family: $f-trueno;
+//       padding: 0;
+//       margin-bottom: 25px;
 
-      li {
-        display: block;
-        padding: 6px 50px 6px 0;
-        position: relative;
-        line-height: 1.42;
-        min-height: 40px;
+//       li {
+//         display: block;
+//         padding: 6px 50px 6px 0;
+//         position: relative;
+//         line-height: 1.42;
+//         min-height: 40px;
 
-        .facet-label a,
-        .facet-count,
-        .selected {
-          font-size: 16px;
-          font-weight: 400;
-          color: $c-font-subtle;
-        }
+//         .facet-label a,
+//         .facet-count,
+//         .selected {
+//           font-size: 16px;
+//           font-weight: 400;
+//           color: $c-font-subtle;
+//         }
 
-        // facet value label
-        .facet-label {
-          padding: 0;
-          text-indent: 0;
-          display: block;
+//         // facet value label
+//         .facet-label {
+//           padding: 0;
+//           text-indent: 0;
+//           display: block;
 
-          &.selected {
-            display: flex;
-            // align-items: center;
-          }
+//           &.selected {
+//             display: flex;
+//             // align-items: center;
+//           }
 
-          a {
-            color: $c-theme-ink;
+//           a {
+//             color: $c-theme-ink;
 
-            &:hover, &:hover {
-              color: $c-theme-ink;
-              border-color: rgba($c-theme-ink,0.5)
-            }
-          }
-        }
+//             &:hover, &:hover {
+//               color: $c-theme-ink;
+//               border-color: rgba($c-theme-ink,0.5)
+//             }
+//           }
+//         }
 
-        // number of results defined by facet value
-        .facet-count {
-          position: absolute;
-          right: 0px;
-          top: 6px;
-          text-align: right;
-          width: auto !important;
-        }
+//         // number of results defined by facet value
+//         .facet-count {
+//           position: absolute;
+//           right: 0px;
+//           top: 6px;
+//           text-align: right;
+//           width: auto !important;
+//         }
 
-        // hide missing icons
-        .icon-missing {
-          display: none;
-        }
+//         // hide missing icons
+//         .icon-missing {
+//           display: none;
+//         }
 
-        // selected facets
-        .selected {
-          color: $c-font-subtle !important;
-          font-weight: 700;
+//         // selected facets
+//         .selected {
+//           color: $c-font-subtle !important;
+//           font-weight: 700;
 
-          &:not(.facet-count){
-            color: $c-theme-ink !important;
-          }
-        }
+//           &:not(.facet-count){
+//             color: $c-theme-ink !important;
+//           }
+//         }
 
-        // selceted facets icon
-        a.remove {
-          border-bottom: 0;
-          height: 22px;
-        }
+//         // selceted facets icon
+//         a.remove {
+//           border-bottom: 0;
+//           height: 22px;
+//         }
 
-      }
-    }
+//       }
+//     }
 
-    // more link when a long list of facet values
-    .more_facets {
-      margin-top:-25px;
-      margin-bottom: 25px;
-      text-align: right;
-    }
+//     // more link when a long list of facet values
+//     .more_facets {
+//       margin-top:-25px;
+//       margin-bottom: 25px;
+//       text-align: right;
+//     }
 
-    li.more_facets {
-      padding: 0;
-      margin: 0;
-    }
-  }
+//     li.more_facets {
+//       padding: 0;
+//       margin: 0;
+//     }
+//   }
 
-  // red arrow toggles
-  .fa {
-    color: $c-theme-red;
-    border-left: 0.425em solid transparent;
-    border-right: 0.425em solid transparent;
-    border-bottom: 0.5em solid currentColor;
-    float: right;
-    position: relative;
-    top: 6px;
-    // height: 9px;
-    font-size: 14px;
-    transition: transform 0.5s ease;
-    margin-left: 9px;
+//   // red arrow toggles
+//   .fa {
+//     color: $c-theme-red;
+//     border-left: 0.425em solid transparent;
+//     border-right: 0.425em solid transparent;
+//     border-bottom: 0.5em solid currentColor;
+//     float: right;
+//     position: relative;
+//     top: 6px;
+//     // height: 9px;
+//     font-size: 14px;
+//     transition: transform 0.5s ease;
+//     margin-left: 9px;
 
-    &.fa-rotate-180, &.fa-caret-down {
-      transform: scaleY(-1);
-    }
-  }
+//     &.fa-rotate-180, &.fa-caret-down {
+//       transform: scaleY(-1);
+//     }
+//   }
 
-  /* --------------------------------------- */
+//   /* --------------------------------------- */
 
-  // date range filter (on HDC)
-  .limit_content.range_limit {
+//   // date range filter (on HDC)
+//   .limit_content.range_limit {
 
-    form {
-      margin: 0 0 10px;
-    }
+//     form {
+//       margin: 0 0 10px;
+//     }
 
-    input.range_begin, input.range_end {
-      padding: 21px 6px 22px 9px;
-      margin-top: -1px;
-      color: $c-font-subtle;
-      width: 4.0em;
-    }
+//     input.range_begin, input.range_end {
+//       padding: 21px 6px 22px 9px;
+//       margin-top: -1px;
+//       color: $c-font-subtle;
+//       width: 4.0em;
+//     }
 
-    input[type="submit"] {
-      background-color: $c-font-subtle;
-      color: $c-white;
-    }
+//     input[type="submit"] {
+//       background-color: $c-font-subtle;
+//       color: $c-white;
+//     }
 
-    input.range_begin {
-      margin-right: 6px;
-    }
+//     input.range_begin {
+//       margin-right: 6px;
+//     }
 
-    input.range_end {
-      margin-right: 7px;
-      margin-left: 6px;
-    }
+//     input.range_end {
+//       margin-right: 7px;
+//       margin-left: 6px;
+//     }
 
-    .btn {
-      padding: 6px 9px;
-    }
-  }
+//     .btn {
+//       padding: 6px 9px;
+//     }
+//   }
 
-  form.range_limit {
-    color: $c-font-base;
+//   form.range_limit {
+//     color: $c-font-base;
 
-    .error {
-      color: $c-font-filter-blue;
-      display: block;
-      font-style: italic;
-      line-height: 1.5;
-      padding-top: 20px;
-      animation-duration: fadeIn 0.8s;
-      animation-fill-mode: both;
-    }
+//     .error {
+//       color: $c-font-filter-blue;
+//       display: block;
+//       font-style: italic;
+//       line-height: 1.5;
+//       padding-top: 20px;
+//       animation-duration: fadeIn 0.8s;
+//       animation-fill-mode: both;
+//     }
 
-    @-webkit-keyframes fadeIn {
-      0% {
-        opacity: 0;
-      }
+//     @-webkit-keyframes fadeIn {
+//       0% {
+//         opacity: 0;
+//       }
 
-      100% {
-        opacity: 1;
-      }
-    }
+//       100% {
+//         opacity: 1;
+//       }
+//     }
 
-    @keyframes fadeIn {
-      0% {
-        opacity: 0;
-      }
+//     @keyframes fadeIn {
+//       0% {
+//         opacity: 0;
+//       }
 
-      100% {
-        opacity: 1;
-      }
-    }
-  }
+//       100% {
+//         opacity: 1;
+//       }
+//     }
+//   }
 
 
-}
+// }

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -1424,7 +1424,7 @@ $pagination-border-width:           none !default;
 // $pagination-focus-outline:          0 !default;
 
 // $pagination-hover-color:            var(--#{$prefix}link-hover-color) !default;
-// $pagination-hover-bg:               var(--#{$prefix}tertiary-bg) !default;
+$pagination-hover-bg:               $background-gray !default;
 // $pagination-hover-border-color:     var(--#{$prefix}border-color) !default; // Todo in v6: remove this?
 
 $pagination-active-color:           $gray-600 !default;

--- a/vendor/assets/stylesheets/_search-results.scss
+++ b/vendor/assets/stylesheets/_search-results.scss
@@ -1,154 +1,185 @@
-.blacklight-catalog-index,
-.blacklight-bookmarks-index {
-  // hide duplicated search-constraints
-  #appliedParams {
-    display: none;
-  }
+.sort-pagination,
+.paginate-section {
+  font-family: $font-family-sans-serif;
+}
 
-  // float columns
-  #sidebar, #content {
-    float: left;
-  }
+.search-widgets {
+  row-gap: 0.5rem;
 
-  // results index
-  .documents-list {
-    margin-bottom: 0;
+  // icon toggles between different views
+  .view-type {
+    a.btn-icon {
+      position: relative;
+      height: 45px;
+      width: 45px;
 
-    .document {
-      border-bottom: none;
-      margin-top: 15px;
-      margin-bottom: 15px;
-
-      &-position-1 {
-        margin-top: 0;
-        padding-top: 0;
+      span.blacklight-icons {
+        position: absolute;
+        left: 10px;
+        top: 9px;
       }
     }
   }
-
-  // items
-  .index-split {
-    display: block;
-
-    // .document-counter {
-    //   display: none;
-    // }
-
-    .index_title {
-      display: block;
-      font-size: 18px;
-      line-height: 25px;
-      text-transform: none;
-      letter-spacing: normal;
-      font-weight: 600;
-      margin-bottom: 3px;
-      padding: 0 20px;
-    }
-
-    .status-icons {
-      margin-left: 0;
-      margin-top: 0;
-      padding: 0 20px;
-      display: flex;
-      flex-wrap: wrap;
-
-      // type styles
-      font-family: $f-trueno;
-      font-size: 12px;
-      font-weight: 600;
-      letter-spacing: 1.71px;
-      line-height: 24px;
-      text-transform: uppercase;
-      color: $c-font-subtle;
-
-      .icon-label {
-        margin-right: 20px;
-      }
-
-      .icon-missing, .icon-missing + .icon-label {
-        display: none;
-      }
-    }
-  }
-
-  // description
-  .more-info-area {
-    max-height: 100%;
-    padding-left: 0;
-    display: flex;
-    grid-gap: 0 20px;
-
-    p {
-      font-size: 14px;
-      line-height: 24px;
-      display: -webkit-box;
-      -webkit-line-clamp: 3;
-      -webkit-box-orient: vertical;
-      margin-bottom: 0;
-    }
-
-    & > div:first-of-type {
-      width: 100%;
-    }
-  }
-
-  // map
-  #map {
-    z-index: 2; // prevents map from appearing on top of filter rail when slides open in mobile view
-    position: sticky !important;
-    top: 20px;
-  }
-  #main-container [data-map="index"] {
-    @media($bp-medium-min){
-        margin: 0 20px;
-        max-width: calc(50% - 40px);
-    }
-  }
-
 }
 
-// restricted icon color
-.blacklight-icon-restricted svg path {
-  fill: $c-theme-red;
+// search result titles
+#documents article.document h3.index_title {
+  font-size: $font-size-base;
+  line-height: 1.5;
+  margin-bottom: 0.25rem;
 }
 
-// harvard icon color
-.blacklight-icon-harvard svg path {
-  fill: $c-theme-crimson;
-}
+// .blacklight-catalog-index,
+// .blacklight-bookmarks-index {
+//   // hide duplicated search-constraints
+//   #appliedParams {
+//     display: none;
+//   }
 
-// top pagination and sorting options
-.pagination .page-links {
-  font-family: $f-trueno;
-  font-size: 15px;
-  line-height: 25px;
-  padding-left: 0;
-  padding-right: 0;
-}
+//   // float columns
+//   #sidebar, #content {
+//     float: left;
+//   }
 
-#sortAndPerPage {
-  align-items: center;
-  border-bottom: 1px solid $c-bd-divider;
+//   // results index
+//   .documents-list {
+//     margin-bottom: 0;
 
-  @media($bp-medium-min){
-    .search-widgets {
-      min-width: 50%;
-      justify-content: flex-end;
-    }
-  }
+//     .document {
+//       border-bottom: none;
+//       margin-top: 15px;
+//       margin-bottom: 15px;
 
-  a.dropdown-item {
-    font-size: 14px;
-    padding-left: 9px;
-    padding-right: 9px;
-  }
+//       &-position-1 {
+//         margin-top: 0;
+//         padding-top: 0;
+//       }
+//     }
+//   }
 
-  @media($bp-medium-max){
-    .page-links {
-      margin: 0 auto;
-    }
-    .search-widgets {
-      justify-content: center;
-    }
-  }
-}
+//   // items
+//   .index-split {
+//     display: block;
+
+//     // .document-counter {
+//     //   display: none;
+//     // }
+
+//     .index_title {
+//       display: block;
+//       font-size: 18px;
+//       line-height: 25px;
+//       text-transform: none;
+//       letter-spacing: normal;
+//       font-weight: 600;
+//       margin-bottom: 3px;
+//       padding: 0 20px;
+//     }
+
+//     .status-icons {
+//       margin-left: 0;
+//       margin-top: 0;
+//       padding: 0 20px;
+//       display: flex;
+//       flex-wrap: wrap;
+
+//       // type styles
+//       font-family: $f-trueno;
+//       font-size: 12px;
+//       font-weight: 600;
+//       letter-spacing: 1.71px;
+//       line-height: 24px;
+//       text-transform: uppercase;
+//       color: $c-font-subtle;
+
+//       .icon-label {
+//         margin-right: 20px;
+//       }
+
+//       .icon-missing, .icon-missing + .icon-label {
+//         display: none;
+//       }
+//     }
+//   }
+
+//   // description
+//   .more-info-area {
+//     max-height: 100%;
+//     padding-left: 0;
+//     display: flex;
+//     grid-gap: 0 20px;
+
+//     p {
+//       font-size: 14px;
+//       line-height: 24px;
+//       display: -webkit-box;
+//       -webkit-line-clamp: 3;
+//       -webkit-box-orient: vertical;
+//       margin-bottom: 0;
+//     }
+
+//     & > div:first-of-type {
+//       width: 100%;
+//     }
+//   }
+
+//   // map
+//   #map {
+//     z-index: 2; // prevents map from appearing on top of filter rail when slides open in mobile view
+//     position: sticky !important;
+//     top: 20px;
+//   }
+//   #main-container [data-map="index"] {
+//     @media($bp-medium-min){
+//         margin: 0 20px;
+//         max-width: calc(50% - 40px);
+//     }
+//   }
+
+// }
+
+// // restricted icon color
+// .blacklight-icon-restricted svg path {
+//   fill: $c-theme-red;
+// }
+
+// // harvard icon color
+// .blacklight-icon-harvard svg path {
+//   fill: $c-theme-crimson;
+// }
+
+// // top pagination and sorting options
+// .pagination .page-links {
+//   font-family: $f-trueno;
+//   font-size: 15px;
+//   line-height: 25px;
+//   padding-left: 0;
+//   padding-right: 0;
+// }
+
+// #sortAndPerPage {
+//   align-items: center;
+//   border-bottom: 1px solid $c-bd-divider;
+
+//   @media($bp-medium-min){
+//     .search-widgets {
+//       min-width: 50%;
+//       justify-content: flex-end;
+//     }
+//   }
+
+//   a.dropdown-item {
+//     font-size: 14px;
+//     padding-left: 9px;
+//     padding-right: 9px;
+//   }
+
+//   @media($bp-medium-max){
+//     .page-links {
+//       margin: 0 auto;
+//     }
+//     .search-widgets {
+//       justify-content: center;
+//     }
+//   }
+// }

--- a/vendor/assets/stylesheets/arclight/_al-item-detail.scss
+++ b/vendor/assets/stylesheets/arclight/_al-item-detail.scss
@@ -200,6 +200,16 @@
       background-color: $black;
     }
   }
+
+  #contents {
+    border-bottom: none;
+
+    table {
+      .al-online-content-icon {
+        margin-right: .5rem;
+      }
+    }
+  }
 }
 
 
@@ -213,7 +223,6 @@
 .online-content-icon-document-container {
   float: right;
 }
-
 
 // small buttons with span icons alignment (no svgs)
 // "request" and "add to my request list"

--- a/vendor/assets/stylesheets/arclight/_al-search-results.scss
+++ b/vendor/assets/stylesheets/arclight/_al-search-results.scss
@@ -22,7 +22,7 @@
     }
 
     // indent and make small gray links look clickable
-    .breadcrumb-links {
+    .breadcrumb-links:not(.al-grouped-repository) {
       margin-left: .5rem;
 
       span.ms-3 {

--- a/vendor/assets/stylesheets/arclight/_al-search-results.scss
+++ b/vendor/assets/stylesheets/arclight/_al-search-results.scss
@@ -1,5 +1,63 @@
 // SEARCH RESULTS PAGE
 .hl__arclight.blacklight-catalog-index {
+  .al-search-breadcrumb {
+    display: none;
+  }
+
+  #documents {
+    // search result card
+    .documents-list article.document,
+    &.documents-list article.document {
+      padding-top: 1.25rem;
+      padding-bottom: .5rem;
+
+      dl {
+        margin-bottom: 0;
+      }
+    }
+
+    .al-document-highlight {
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+    }
+
+    // indent and make small gray links look clickable
+    .breadcrumb-links {
+      margin-left: .5rem;
+
+      span.ms-3 {
+        margin-left: 0 !important;
+      }
+
+      a {
+        text-decoration: dotted underline;
+        border-bottom: 0;
+
+        &:hover, &:focus {
+          text-decoration-style: solid;
+        }
+      }
+    }
+
+    // gray box title when "grouped by collection"
+    .al-grouped-title-bar {
+      h3, .h3 {
+        line-height: 1.5;
+      }
+    }
+
+    // extent badge
+    article.document .document-title-heading .al-document-extent {
+      background-color: $background-gray;
+    }
+  }
+
+  // section header that says "Top # results"
+  .al-grouped-results .al-grouped-more {
+    font-family: $font-family-sans-serif;
+    margin-bottom: 0;
+  }
+ 
   // container for "Collection Identifier"
   .online-content-icon-document-container {
     .al-document-container.text-muted {
@@ -9,5 +67,10 @@
       display: inline-flex;
       align-items: center;
     }
+  }
+
+  ul.pagination {
+    border-top: none;
+    padding-top: 0;
   }
 }

--- a/vendor/assets/stylesheets/geoblacklight/geoblacklight-patterns.scss
+++ b/vendor/assets/stylesheets/geoblacklight/geoblacklight-patterns.scss
@@ -1,4 +1,4 @@
 // PATTERNS SPECIFIC TO HARVARD GEOSPATIAL LIBRARY
-@import 'homepage';
+@import 'gbl-homepage';
 @import 'gbl-index-map-explorer';
 @import 'gbl-leaflet';

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -19,14 +19,14 @@
 
 // PATTERNS
 @import 'alert-banner';
-// @import 'facets';
+@import 'facets';
 @import 'footer';
 @import 'header-child';
 // @import 'icon-list';
 @import 'item-detail';
 // @import 'modal-windows';
 // @import 'other-screens';
-// @import 'search-results';
+@import 'search-results';
 // @import 'searchbar';
 @import 'topbar-nav';
 


### PR DESCRIPTION
**Style updates for Results page**
* * *

**JIRA Ticket**: [LTSARC-24](https://at-harvard.atlassian.net/browse/LTSARC-24)

# What does this Pull Request do?
Implement style updates across the “Results” page views (All Results, Grouped by Collection, List View, and Compact View).

# How should this be tested?

Using the [arclight repo branch LTSARC-24](https://github.com/harvard-lts/arclight/tree/LTSARC-24), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-24"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.5).

Start up ArcLight and confirm the following style updates:

- [x] Breadcrumbs no longer appear
- [x] Dropdowns at top of page (not the filter rail) are resized for better usability (all buttons are aligned/the same height).
- [x] Results count text at top of page says "Showing # of # results/items/collections" and does not include the prev/next buttons.
- [x] Light gray background used for collection backround + the other badges on the page
- [x] Links within search results appear clickable (dotted underline that turns to solid underline on hover/focus)
- [x] Under "Grouped by Collection" page, language has been updated to say "Top 3 results in this collection - view all #)
- [x] Pagination matches other *lites and is displayed only at the bottom of the page.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

[LTSARC-24]: https://at-harvard.atlassian.net/browse/LTSARC-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ