### PR TITLE
LTSARC-45 & LTSARC-46: styles changes

### DIFF
--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.5"
+      VERSION = "0.6"
     end
   end
 end

--- a/vendor/assets/stylesheets/_header-child.scss
+++ b/vendor/assets/stylesheets/_header-child.scss
@@ -2,6 +2,8 @@
 // slight customization from PatternLab (with the site title link)
 
 .hl__header-child {
+  min-height: 60px;
+  
   &__title {
     background-image: linear-gradient(-46deg, $c-theme-secondary 0%, $c-theme-secondary-dark 100%);
     color: $c-font-inverse;

--- a/vendor/assets/stylesheets/arclight/_al-facets.scss
+++ b/vendor/assets/stylesheets/arclight/_al-facets.scss
@@ -36,6 +36,7 @@ a.exclude-facet {
   &[rel="nofollow"] {
     .material-symbols-outlined {
       visibility: hidden;
+      font-size: 20px;
     }
   }
 
@@ -44,7 +45,6 @@ a.exclude-facet {
       .material-symbols-outlined {
         visibility: visible;
         color: $red;
-        font-size: 20px;
         border: 0;
       }
     }

--- a/vendor/assets/stylesheets/arclight/_al-facets.scss
+++ b/vendor/assets/stylesheets/arclight/_al-facets.scss
@@ -51,7 +51,6 @@ a.exclude-facet {
   .exclude-filter {
     span {
       text-decoration: line-through;
-      color: $red;
     }
   }
 }

--- a/vendor/assets/stylesheets/arclight/_al-facets.scss
+++ b/vendor/assets/stylesheets/arclight/_al-facets.scss
@@ -36,10 +36,15 @@ a.exclude-facet {
   &[rel="nofollow"] {
     .material-symbols-outlined {
       visibility: hidden;
+    }
+  }
 
-      &:hover, &:focus {
+  &:hover, &:focus {
+    &[rel="nofollow"] {
+      .material-symbols-outlined {
         visibility: visible;
         color: $red;
+        font-size: 20px;
         border: 0;
       }
     }


### PR DESCRIPTION
**LTSARC-45 & LTSARC-46: styles changes**
* * *

**JIRA Tickets**: 
* [LTSARC-45: Make "Exclude facet" filter discoverable on focus with keyboard](https://at-harvard.atlassian.net/browse/LTSARC-45)
* [LTSARC-46: Remove red style treatment when constraints are excluded](https://at-harvard.atlassian.net/browse/LTSARC-46)

# What does this Pull Request do?
Implements the style changes necessary to resolve accessibility issues related to the custom "exclude" feature.

# How should this be tested?
Using the arclight repo branch [LTSARC-45_exclude-facet-focus](https://github.com/harvard-lts/arclight/tree/LTSARC-45), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-46_exclude-constraint"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.6).

Start up ArcLight and confirm the following style updates:
- [ ] After selecting a filter constraint to exclude, the selected value will appear next to the "Start Over" button with a strikethough, but no red color
- [ ] Tabbing through the filter rail, the exclude filter link will receive focus (this looks like a red funnel)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No