### PR TITLE
LTSARC-51: Update header for mobile views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.1)
+    harvard-patterns-gem (0.7)
       rails
       sass
       sass-rails

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.6"
+      VERSION = "0.7"
     end
   end
 end

--- a/vendor/assets/stylesheets/_header-child.scss
+++ b/vendor/assets/stylesheets/_header-child.scss
@@ -3,6 +3,12 @@
 
 .hl__header-child {
   min-height: 60px;
+  background-color: $black;
+  flex-wrap: nowrap;
+
+  @include media-breakpoint-down(sm) {
+    flex-wrap: wrap;
+  }
   
   &__title {
     background-image: linear-gradient(-46deg, $c-theme-secondary 0%, $c-theme-secondary-dark 100%);
@@ -72,12 +78,8 @@
       margin: 4px;
 
       @include media-breakpoint-down(md) {
-        padding: 6px 10px;
+        padding: 7px 16px;
       }
-    }
-
-    .hl__logo-shield {
-      max-height: 40px;
     }
   }
 }


### PR DESCRIPTION
**LTSARC-51: Update header for mobile views**
* * *

**JIRA Ticket**: [LTSARC-51](https://at-harvard.atlassian.net/browse/LTSARC-51)

# What does this Pull Request do?
Updates header to always include the entire HL logo with the words “Harvard Library”, not just the shield (like it was doing on mobile view before).

# How should this be tested?
Using the arclight repo branch [LTSARC-51_header](https://github.com/harvard-lts/arclight/tree/LTSARC-51_header), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-51_header"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.7).

Start up ArcLight and confirm the following style updates to the header:
- [x] Full Harvard Library logo (shield + words) is always present, regardless of screen size
- [x] On small screen sizes, the logo wraps below the teal title bar

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No


[LTSARC-51]: https://at-harvard.atlassian.net/browse/LTSARC-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ