### PR TITLE
[WIP] Make available as an npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "harvard-patterns",
+  "version": "0.1.1",
+  "files": [
+    "vendor/assets"
+  ],
+  "dependencies": {
+    "bootstrap-icons": "^1.11.3",
+    "bootstrap": "^5.3.3",
+    "sass": "^1.80.6",
+    "scss": "^0.2.4"
+  },
+  "peerDependencies": {
+    "bootstrap": "^5.3.3"
+  }
+}

--- a/vendor/assets/stylesheets/_harvard-patterns-base.scss
+++ b/vendor/assets/stylesheets/_harvard-patterns-base.scss
@@ -1,0 +1,29 @@
+// This is the main scss file for Harvard Patterns
+
+@import 'fonts';
+
+// CUSTOM BOOTSTRAP 5 VARIABLE OVERRIDES
+@import 'harvard-bootstrap';
+
+// GLOBAL STYLES & MIXINS
+// @import 'variables';
+// @import 'breakpoints';
+@import 'colors';
+// @import 'container';
+// @import 'typography';
+@import 'global';
+// @import 'links-and-buttons';
+@import 'visually-hidden';
+
+// PATTERNS
+@import 'alert-banner';
+@import 'facets';
+@import 'footer';
+@import 'header-child';
+// @import 'icon-list';
+@import 'item-detail';
+@import 'modal-windows';
+// @import 'other-screens';
+@import 'search-results';
+// @import 'searchbar';
+@import 'topbar-nav';

--- a/vendor/assets/stylesheets/geoblacklight/geoblacklight-patterns.scss
+++ b/vendor/assets/stylesheets/geoblacklight/geoblacklight-patterns.scss
@@ -1,3 +1,11 @@
+// BREAKPOINT VARIABLES NOT ALREADY DEFINED
+$bp-x-small-min: 0;
+$bp-x-small-max: 575px;
+$bp-small-min: 576px;
+$bp-small-max: 991px;
+$bp-large-min: 992px;
+$bp-large-max: 1199px;
+
 // PATTERNS SPECIFIC TO HARVARD GEOSPATIAL LIBRARY
 @import 'gbl-homepage';
 @import 'gbl-index-map-explorer';

--- a/vendor/assets/stylesheets/harvard-patterns-node.scss
+++ b/vendor/assets/stylesheets/harvard-patterns-node.scss
@@ -1,0 +1,7 @@
+// BOOTSTRAP MIXINS
+@import "../node_modules/bootstrap/scss/mixins";
+
+@import 'harvard-patterns-base';
+
+// BOOTSTRAP 5
+@import "../node_modules/bootstrap/scss/bootstrap";

--- a/vendor/assets/stylesheets/harvard-patterns.scss
+++ b/vendor/assets/stylesheets/harvard-patterns.scss
@@ -1,34 +1,7 @@
-// This is the main scss file for Harvard Patterns
-
+// BOOTSTRAP MIXINS
 @import 'bootstrap/mixins';
 
-@import 'fonts';
-
-// CUSTOM BOOTSTRAP 5 VARIABLE OVERRIDES
-@import 'harvard-bootstrap';
-
-// GLOBAL STYLES & MIXINS
-// @import 'variables';
-// @import 'breakpoints';
-@import 'colors';
-// @import 'container';
-// @import 'typography';
-@import 'global';
-// @import 'links-and-buttons';
-@import 'visually-hidden';
-
-// PATTERNS
-@import 'alert-banner';
-@import 'facets';
-@import 'footer';
-@import 'header-child';
-// @import 'icon-list';
-@import 'item-detail';
-@import 'modal-windows';
-// @import 'other-screens';
-@import 'search-results';
-// @import 'searchbar';
-@import 'topbar-nav';
+@import 'harvard-patterns-base';
 
 // BOOTSTRAP 5
 @import 'bootstrap';


### PR DESCRIPTION
[Work in progress]

- Makes the scss available as an npm-style package.
- Refactors the harvard-patterns.scss files into a file for use with sprockets rails apps as well as another file for use with rails apps using `vite` or `cssbundling-rails`.
- Add a few missing variables into the `geoblacklight.scss` file.