### PR TITLE
Digital Object Link Titles Too Long

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.7)
+    harvard-patterns-gem (0.8)
       rails
       sass
       sass-rails

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.7"
+      VERSION = "0.8"
     end
   end
 end

--- a/vendor/assets/stylesheets/arclight/_al-item-detail.scss
+++ b/vendor/assets/stylesheets/arclight/_al-item-detail.scss
@@ -73,14 +73,21 @@
     }
 
     iframe {
-      padding-bottom: 1.25rem;
+      height: 48rem;
     }
   }
 
   // embed thumbnails option
   .show-document {
     .thumbnail-card {
-      width: 12.5rem
+      width: 12.5rem;
+
+      .card-text {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        overflow: hidden;
+      }
     }
   }
 


### PR DESCRIPTION
**Digital Object Link Titles Too Long**
* * *

**JIRA Ticket**: [LTSARC-38](https://at-harvard.atlassian.net/browse/LTSARC-37)

# What does this Pull Request do?
Truncates digital object thumbnail titles to 3 lines and updates oembed iframe styling so there's no more overlapping of components.

# How should this be tested?
Using the arclight repo branch [LTSARC-37_truncate-titles](https://github.com/harvard-lts/arclight/tree/LTSARC-37_truncate-titles), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-37_truncate-titles"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 0.8).

Start up ArcLight and confirm the following updates to digital objects:
- [x] If thumbnail is present ("M. Alphonse Boni" example from Law), thumbnail image appears followed by three lines of the title
- [x] If thumbnail is not present ("School calendars and correspondence" example from Schlesinger), there is no longer an empty div
- [x] There is no longer any overlap of components in the Digital Content section

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

[LTSARC-38]: https://at-harvard.atlassian.net/browse/LTSARC-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ