### PR TITLE
package.json for Rails8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.9)
+    harvard-patterns-gem (0.9.0)
       rails
       sass
       sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.8)
+    harvard-patterns-gem (0.9)
       rails
       sass
       sass-rails

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.8"
+      VERSION = "0.9"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.9"
+      VERSION = "0.9.0"
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "harvard-patterns",
+  "version": "0.9"
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "harvard-patterns",
-  "version": "0.9"
+  "version": "0.9.0"
 }


### PR DESCRIPTION
Add `package.json`

This commit will bump the version and add a `package.json`.  We are
currently developing a new instance of CURIOsity on Rails 8 and it is
using Propshaft for assets.  Because this gem has a dependency on
`sassc-rails` which has `sprockets` as a dependency, it's not playing
well with our instance.  We are going to take notes from the HGL
implmentation and install it through yarn instead.  The next problem we
faced is that this gem's `harvard-patterns.scss` imports bootstrap a
particular way that again isn't compatible with how the new CURIOsity
imports it.  To solve this we are using patch-package so we can change
the @import paths locally to what works for us.  Right now, because we
don't have a `package.json` which patch-package is looking for, we'd
need an extra command to create essentially a dummy one to make the
patch work.

This commit will make our patch process a lot smoother by actually
having a `package.json` for it to refer to.

This should not have any impact on arclight as it simply adds a package.json and bumps the version