### PR TITLE
Update body text to Sourc Sans 3 (Pro)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.9.0)
+    harvard-patterns-gem (1.0.0)
       rails
       sass
       sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.8)
+    harvard-patterns-gem (0.9)
       rails
       sass
       sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harvard-patterns-gem (0.7)
+    harvard-patterns-gem (0.8)
       rails
       sass
       sass-rails

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ meld /path/to/target-project/harvard-patterns-gem-0.1.0/vendor/assets/stylesheet
 If happy with preview, sync changes:
 ```zsh
 # From target project
-cp -R harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/* /path/to/harvard-patterns-gem/vendor/assets/stylesheets/
+cp -R /path/to/harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/* /path/to/harvard-patterns-gem/vendor/assets/stylesheets/
 ```
 
 ### 6. Commit Changes and Test New Branch

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Images should be referenced using standard Rails asset helpers:
 
 In ERB Views:
 
-```bash
+```zsh
 <%= image_tag "logo.png" %>
 ```
 
@@ -82,11 +82,75 @@ Note: Images may also need to be declared in your `manifest.js` file:
 ## Local Development
 If you want to modify the gem for local development and test it in another project, follow these steps:
 
-### 1. Make Changes in a New Branch
-Create a new branch and add your changes there. Commit changes.
+### 1. Build Gem Locally in New Branch
+Create a new branch and build the gem locally:
 
-### 2. Link the Gem
-In the target project's `Gemfile`, link the gem to your branch name:
+```zsh
+gem build harvard-patterns-gem.gemspec
+```
+
+### 2. Unpack Gem in Target Project
+Navigate to the target project and unpack the gem:
+
+```zsh
+cd /path/to/target-project
+gem unpack /path/to/harvard-patterns-gem-0.1.0.gem
+```
+
+Note: Numbers at the end should match the gem's version number.
+
+### 3. Import Stylesheets from Local Gem
+In your target project, update the stylesheet file (`app/assets/stylesheets/application.css` or similar) to point to the unpacked stylesheets.
+
+Instead of:
+
+```scss
+@import 'harvard-patterns';
+```
+
+Use a relative path that points to the unpacked stylesheets (adjust path as needed):
+
+```scss
+@import '../harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/harvard-patterns.scss';
+```
+
+### 4. Make SCSS Changes in Target Project (Temporary)
+Edit the unpacked SCSS files directly inside your target project to test styling changes live in the UI.
+
+### 5. Preview and Sync Changes
+Preview changes between the unpacked gem in your target project and original gem:
+
+View line-by-line differences in the terminal (similar to git diff)
+```zsh
+diff -ruN \
+  /path/to/target-project/harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/ \
+  /path/to/harvard-patterns-gem/vendor/assets/stylesheets/
+```
+
+or use a GUI tool to get a side-by-side comparison of all file differences
+```zsh
+meld /path/to/target-project/harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/ /path/to/harvard-patterns-gem/vendor/assets/stylesheets/
+```
+
+If happy with preview, sync changes:
+```zsh
+# From target project
+cp -R harvard-patterns-gem-0.1.0/vendor/assets/stylesheets/* /path/to/harvard-patterns-gem/vendor/assets/stylesheets/
+```
+
+### 6. Commit Changes and Test New Branch
+
+#### In `harvard-patterns-gem`
+* Remove the built gemspec (`harvard-patterns-gem-0.1.0.gemspec`).
+* View synced changes to confirm they're what you want.
+* Commit changes into your new branch.
+
+#### In Target Project
+Remove all local references to harvard-patterns-gem-0.1.0:
+* Delete unpacked gem (`harvard-patterns-gem-0.1.0`)
+* Change your stylesheet import back to `@import 'harvard-patterns'`
+
+In the `Gemfile`, link the gem to your branch name:
 ```ruby
 gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "BRANCH-NAME"
 ```
@@ -97,19 +161,7 @@ Check your `Gemfile.lock` to confirm the change has been made. You should see th
 
 Changes will immediately reflect in the project using this version of the gem after a restart or asset recompile.
 
-### 3. Iterate on Changes (optional)
-I recommend the following steps after every new commit you want to test to ensure you are testing the newest changes. 
-
-In the gem:
-* Make and commit additional changes.
-* Update the version of your gem in `version.rb` (can be anything, just different from the previous version). This helps to visually recognize that you are using the most up-to-date code in your branch.
-
-In the target project:
-* Remove your `Gemfile.lock`.
-* Reinstall with `bundle install` and confirm the new `Gemfile.lock` includes the version you just created.
-* Restart the gem to view your changes.
-
-### 4. Revert to Remote Version
+### 7. Revert to Remote Version
 Once you're done with local development and testing, switch back to the remote gem in the Gemfile:
 
 ```ruby
@@ -119,7 +171,6 @@ gem 'harvard-patterns-gem', git: 'https://github.com/harvard-lts/harvard-pattern
 Run `bundle install` to apply the change.
 
 Check your `Gemfile.lock` to confirm the change has been made. You should see a tag number instead of a branch name.
-
 
 ## Creating a New Version and Updating in Projects
 
@@ -133,6 +184,8 @@ module HarvardPatternsGem
   VERSION = '1.1.0' # Update to the new version
 end
 ```
+
+Run `bundle install` to apply the change.
 
 Commit the version bump using your terminal or the GitHub interface:
 ```zsh

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.9.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.8"
+      VERSION = "0.9"
     end
   end
 end

--- a/lib/harvard/patterns/gem/version.rb
+++ b/lib/harvard/patterns/gem/version.rb
@@ -1,7 +1,7 @@
 module Harvard
   module Patterns
     module Gem
-      VERSION = "0.7"
+      VERSION = "0.8"
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "harvard-patterns",
-  "version": "0.9.0"
+  "version": "1.0.0"
 }

--- a/vendor/assets/stylesheets/_fonts.scss
+++ b/vendor/assets/stylesheets/_fonts.scss
@@ -1,6 +1,9 @@
 // LORA
 @import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap');
 
+// SOURCE SANS 3
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;600;700&display=swap");
+
 // TRUENO
 @font-face {
   font-family: "Trueno";

--- a/vendor/assets/stylesheets/_harvard-bootstrap.scss
+++ b/vendor/assets/stylesheets/_harvard-bootstrap.scss
@@ -6,6 +6,7 @@
 // https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss
 
 $f-lora: Lora, Georgia, serif; // custom variable
+$f-source-sans: "Source Sans 3", sans-serif; // custom variable
 $f-trueno: "Trueno", sans-serif; // custom variable
 
 // Color system
@@ -23,7 +24,7 @@ $gray-800: #414141 !default;
 $gray-900: #1e1e1e !default;
 $black:    #1e1e1e !default;
 $border-gray: #AFAFAF; // custom variable
-$background-gray: #F3F3F3; // custom variable
+$background-gray: #F2F2F2; // custom variable
 // scss-docs-end gray-color-variables
 
 // fusv-disable

--- a/vendor/assets/stylesheets/arclight/_al-fonts.scss
+++ b/vendor/assets/stylesheets/arclight/_al-fonts.scss
@@ -1,0 +1,11 @@
+// FONTS
+
+// Arclight Variables
+// Overrides Harvard Custom variables to change almost all fonts to "Source Sans 3"
+
+$f-source-sans: "Source Sans 3", sans-serif; // custom variable
+
+// Typography
+$font-family-sans-serif:      $f-source-sans !default;
+$font-family-base:            $f-source-sans !default;
+$headings-font-family:        $font-family-sans-serif !default;

--- a/vendor/assets/stylesheets/arclight/_al-item-detail.scss
+++ b/vendor/assets/stylesheets/arclight/_al-item-detail.scss
@@ -73,14 +73,21 @@
     }
 
     iframe {
-      padding-bottom: 1.25rem;
+      height: 48rem;
     }
   }
 
   // embed thumbnails option
   .show-document {
     .thumbnail-card {
-      width: 12.5rem
+      width: 12.5rem;
+
+      .card-text {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        overflow: hidden;
+      }
     }
   }
 

--- a/vendor/assets/stylesheets/arclight/_al-item-detail.scss
+++ b/vendor/assets/stylesheets/arclight/_al-item-detail.scss
@@ -248,7 +248,7 @@ button.btn-sm {
       border: 1px solid $border-gray;
       border-radius: 4px 0 0 4px;
       border-right: 0;
-      border-left-color: $red;
+      border-left-color: $yellow;
       border-left-width: 6px;
       padding: 1.25rem;
       margin-bottom: 1rem;
@@ -271,7 +271,7 @@ button.btn-sm {
     dd.blacklight-restrictions,
     dd.blacklight-parent_restrictions {
       padding: 1.25rem 2.25rem .25rem 1.25rem;
-      border-left: 6px solid $red;
+      border-left: 6px solid $yellow;
       border-radius: 4px 4px 0 0;
       margin: 0 1rem;
     }

--- a/vendor/assets/stylesheets/arclight/_al-my-request-list.scss
+++ b/vendor/assets/stylesheets/arclight/_al-my-request-list.scss
@@ -66,7 +66,7 @@
 
         &.blacklight-restrictions {
           border: 1px solid $border-gray;
-          border-left: 6px solid $red;
+          border-left: 6px solid $yellow;
           border-right: 0;
           border-radius: 4px 0 0 4px;
           padding-top: .75rem;
@@ -90,7 +90,7 @@
       dt.blacklight-restrictions,
       dd.blacklight-restrictions {
         padding: .75rem 2.25rem .25rem 1.25rem;
-        border-left: 6px solid $red;
+        border-left: 6px solid $yellow;
         border-radius: 4px 4px 0 0;
         margin: 0 1rem;
       }

--- a/vendor/assets/stylesheets/arclight/_al-search-results.scss
+++ b/vendor/assets/stylesheets/arclight/_al-search-results.scss
@@ -20,20 +20,34 @@
       align-items: center;
     }
   }
+
+  // pagination at top of page
+  .page-links {
+    font-size: 1.25rem;
+  }
 }
 
 
 // metadata card views (on search results and :my request list" pages)
 #documents {
+  // search result card
+  article.document {
+    h3, .h3 {
+      &.index_title {
+        font-size: 1.25rem;
+      }
+    }
+
+    dl {
+      margin-bottom: 0;
+    }
+  }
+
   // search result card - list view
   .documents-list article.document,
   &.documents-list article.document {
     padding-top: 1.25rem;
     padding-bottom: .5rem;
-
-    dl {
-      margin-bottom: 0;
-    }
   }
 
   // search result card - compact view
@@ -41,15 +55,16 @@
   &.documents-compact article.document {
     padding-top: 1rem;
     padding-bottom: .5rem;
-
-    dl {
-      margin-bottom: 0;
-    }
   }
       
   .al-document-highlight {
     padding-left: 1.25rem;
     padding-right: 1.25rem;
+
+    // highlight color
+    em {
+      background-color: #FFFCC8;
+    }
   }
 
   // indent and make small gray links look clickable
@@ -70,15 +85,38 @@
     }
   }
 
-  // gray box title when "grouped by collection"
+  // gray box when "grouped by collection"
   .al-grouped-title-bar {
     h3, .h3 {
+      font-size: 22px;
       line-height: 1.5;
+      margin-bottom: 2px;
+    }
+
+    .al-grouped-repository.breadcrumb-links {
+      font-size: 1em;
+      margin-bottom: 0;
+    }
+  }
+
+  .al-document-abstract-or-scope {
+    font-size: 1em;
+
+    button {
+      font-size: 0.85em;
     }
   }
 
   // extent badge
   article.document .document-title-heading .al-document-extent {
     background-color: $background-gray;
+  }
+
+  // secondary links
+  .al-grouped-repository.breadcrumb-links,
+  .al-grouped-more {
+    a {
+      color: $teal;
+    }
   }
 }

--- a/vendor/assets/stylesheets/arclight/_al-typography.scss
+++ b/vendor/assets/stylesheets/arclight/_al-typography.scss
@@ -1,0 +1,13 @@
+// TYPOGRAPHY
+
+// CHANGE LINKS TO SOURCE SANS (except harvard header and footer links)
+header nav a, 
+main a:not(.btn), 
+main .btn-link {
+  font-family: $f-source-sans !important;
+}
+
+// REVERT FOOTER TEXT BACK TO TRUENO
+.hl__footer .hl__footer__content {
+  font-family: $f-trueno;
+}

--- a/vendor/assets/stylesheets/arclight/arclight-patterns.scss
+++ b/vendor/assets/stylesheets/arclight/arclight-patterns.scss
@@ -1,4 +1,5 @@
 // PATTERNS SPECIFIC TO HOLLIS FOR ARCHIVAL DISCOVERY
+@import 'al-typography';
 @import 'al-facets';
 @import 'al-item-detail';
 @import 'al-masthead';

--- a/vendor/assets/stylesheets/arclight/typography.scss
+++ b/vendor/assets/stylesheets/arclight/typography.scss
@@ -1,0 +1,75 @@
+// TYPOGRAPHY
+
+// Arclight Variables
+// Overrides Harvard Custom variables to change almost all fonts to "Source Sans 3"
+
+$f-source-sans: "Source Sans 3", sans-serif; // custom variable
+
+// Links
+// custom link styles
+.hl__arclight {
+  header nav a, main a:not(.btn), main .btn-link {
+    font-family: $f-source-sans;
+    color: red !important;
+  }
+}
+// end custom links styles
+
+
+// Typography
+$font-family-sans-serif:      $f-source-sans !default;
+$font-family-base:            $f-source-sans !default;
+$headings-font-family:        $font-family-sans-serif !default;
+
+
+// Tables
+// custom table styles
+table, .table {
+  font-family: $font-family-sans-serif;
+}
+// end custom table styles
+
+
+// Buttons + Forms
+// $input-btn-font-family:       $font-family-sans-serif !default;
+
+
+// Buttons
+// $btn-font-family:             $font-family-sans-serif !default;
+
+// Forms
+// custom input-group styles
+.input-group-text {
+  font-family: $font-family-sans-serif;
+}
+// end custom input-group styles
+
+// custom label styles
+label {
+  font-family: $font-family-sans-serif;
+}
+// end custom label styles
+
+
+// Tooltips
+// custom tooltip styles
+.tooltip {
+  font-family: $font-family-sans-serif;
+}
+// end custom tooltip styles
+
+
+// Badges
+// custom badge styles
+.badge {
+  font-family: $font-family-sans-serif;
+}
+// end custom badge styles
+
+
+// Breadcrumbs
+// custom breadcrumb styles
+.breadcrumb {
+  font-family: $font-family-sans-serif;
+}
+// end custom breadcrumb styles

--- a/vendor/assets/stylesheets/arclight/typography.scss
+++ b/vendor/assets/stylesheets/arclight/typography.scss
@@ -10,7 +10,6 @@ $f-source-sans: "Source Sans 3", sans-serif; // custom variable
 .hl__arclight {
   header nav a, main a:not(.btn), main .btn-link {
     font-family: $f-source-sans;
-    color: red !important;
   }
 }
 // end custom links styles


### PR DESCRIPTION
**Update body text to Source Sans 3 (Pro)**
* * *

**JIRA Ticket**: Unofficial work, but related to [LTSARC-50](https://at-harvard.atlassian.net/browse/LTSARC-50)

# What does this Pull Request do?
Changes body text to Source Sans 3 as well as other minor style changes.

# How should this be tested?
Using the arclight repo branch [LTSARC-50_source-sans-3](https://github.com/harvard-lts/arclight/tree/LTSARC-50_source-sans-3), link the gem to ArcLight's `Gemfile` from this branch:

``` ruby
gem "harvard-patterns-gem", git: "https://github.com/harvard-lts/harvard-patterns-gem", branch: "LTSARC-50_source-sans-3"
```

Run `bundle install` to install the gem.

Check your `Gemfile.lock` to confirm the gem has been added (you will see the branch name and the version as 1.0.0).

Start up ArcLight and confirm the following updates:
- [x] All body text is "Source Sans 3" (with the exception of the Harvard custom header and footer areas)
- [x] Yellow highlight color is `#FFFCC8`
- [x] Eyebrow links to repositories (in the gray box above the collection title) and "view all #" links on the search results page are a teal color `#3e6f7d` (these both appear on a search results page when "Grouped by collection")
- [x] Restrictions box has a yellow border `#f8c21c` on the left side (used to be red)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

[LTSARC-50]: https://at-harvard.atlassian.net/browse/LTSARC-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ