### PR TITLE
LTSDISC-147 Upgrading rails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in harvard-patterns-gem.gemspec
 gemspec
 
+gem 'rails', '~> 7.1.2'
 gem "rake", "~> 12.0"
 gem 'bootstrap', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (0.6.1)
-      actionpack (>= 0.9.5)
+    actioncable (7.1.5.2)
+      actionpack (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.5.2)
+      actionpack (= 7.1.5.2)
+      activejob (= 7.1.5.2)
+      activerecord (= 7.1.5.2)
+      activestorage (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.5.2)
+      actionpack (= 7.1.5.2)
+      actionview (= 7.1.5.2)
+      activejob (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
     actionpack (7.1.5.2)
       actionview (= 7.1.5.2)
       activesupport (= 7.1.5.2)
@@ -21,18 +45,34 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.5.2)
+      actionpack (= 7.1.5.2)
+      activerecord (= 7.1.5.2)
+      activestorage (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
     actionview (7.1.5.2)
       activesupport (= 7.1.5.2)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    activejob (7.1.5.2)
+      activesupport (= 7.1.5.2)
+      globalid (>= 0.3.6)
     activemodel (7.1.5.2)
       activesupport (= 7.1.5.2)
     activerecord (7.1.5.2)
       activemodel (= 7.1.5.2)
       activesupport (= 7.1.5.2)
       timeout (>= 0.4.0)
+    activestorage (7.1.5.2)
+      actionpack (= 7.1.5.2)
+      activejob (= 7.1.5.2)
+      activerecord (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      marcel (~> 1.0)
     activesupport (7.1.5.2)
       base64
       benchmark (>= 0.3)
@@ -73,6 +113,8 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux)
     ffi (1.17.1-x86_64-linux-musl)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -83,8 +125,26 @@ GEM
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.1.0)
+    mini_mime (1.1.5)
     minitest (5.25.4)
     mutex_m (0.3.0)
+    net-imap (0.5.12)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-musl)
@@ -114,11 +174,20 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
-    rails (0.9.5)
-      actionmailer (>= 0.6.1)
-      actionpack (>= 1.4.0)
-      activerecord (>= 1.6.0)
-      rake (>= 0.4.15)
+    rails (7.1.5.2)
+      actioncable (= 7.1.5.2)
+      actionmailbox (= 7.1.5.2)
+      actionmailer (= 7.1.5.2)
+      actionpack (= 7.1.5.2)
+      actiontext (= 7.1.5.2)
+      actionview (= 7.1.5.2)
+      activejob (= 7.1.5.2)
+      activemodel (= 7.1.5.2)
+      activerecord (= 7.1.5.2)
+      activestorage (= 7.1.5.2)
+      activesupport (= 7.1.5.2)
+      bundler (>= 1.15.0)
+      railties (= 7.1.5.2)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -175,6 +244,10 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -190,6 +263,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap (~> 5.1)
   harvard-patterns-gem!
+  rails (~> 7.1.2)
   rake (~> 12.0)
 
 BUNDLED WITH


### PR DESCRIPTION
**LTSDISC-147 Upgrading rails.**
* * *

**JIRA Ticket**: [LTSDISC-147](https://at-harvard.atlassian.net/browse/LTSDISC-147)

# What does this Pull Request do?
This upgrades the critical security patches for the Harvard Patterns Gem.

# How should this be tested?

A description of what steps someone could take to:
* Arclight is using the Harvard Pattern Gem, so we can test this locally by pulling in the working branch of the Pattern Gem.
* In your local version of Arclight, change the Gemfile to use this: `gem 'harvard-patterns-gem', git: 'https://github.com/harvard-lts/harvard-patterns-gem', branch: 'LTSDISC-147-upgrade-rails'`
* After making the change to the Gemfile, run `bundle install` and confirm that the Gemfile.lock is using the `LTSDISC-147-upgrade-rails` branch
* Rebuild the Arclight container
* Confirm that the Arclight front-end still looks good and is using the Harvard styles.
* Once you are done testing Arclight, you can revert the changes to your local Arclight.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
Tag (@ mention) interested parties

[LTSDISC-147]: https://at-harvard.atlassian.net/browse/LTSDISC-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ